### PR TITLE
replaces resty function wrappers with direct calls

### DIFF
--- a/core/v2/cmdb/ci.go
+++ b/core/v2/cmdb/ci.go
@@ -2,103 +2,18 @@ package cmdb
 
 import (
 	"fmt"
+	"gopkg.in/resty.v1"
 	"strconv"
 )
 
-type EmployeeReturn struct {
-	Data struct {
-		Data struct {
-			AttributeList struct {
-				One struct {
-					AttributeGroupID    string      `json:"attribute_group_id"`
-					AttributeTypeID     string      `json:"attribute_type_id"`
-					Column              string      `json:"column"`
-					Description         string      `json:"description"`
-					DisplayStyle        interface{} `json:"display_style"`
-					Hint                string      `json:"hint"`
-					Historicize         string      `json:"historicize"`
-					ID                  string      `json:"id"`
-					InputMaxlength      interface{} `json:"input_maxlength"`
-					IsActive            string      `json:"is_active"`
-					IsAutocomplete      string      `json:"is_autocomplete"`
-					IsBold              string      `json:"is_bold"`
-					IsEvent             string      `json:"is_event"`
-					IsMultiselect       string      `json:"is_multiselect"`
-					IsNumeric           string      `json:"is_numeric"`
-					IsProjectRestricted string      `json:"is_project_restricted"`
-					IsUnique            string      `json:"is_unique"`
-					IsUniqueCheck       string      `json:"is_unique_check"`
-					Name                string      `json:"name"`
-					Note                string      `json:"note"`
-					OrderNumber         string      `json:"order_number"`
-					Regex               interface{} `json:"regex"`
-					ScriptName          interface{} `json:"script_name"`
-					Tag                 string      `json:"tag"`
-					TextareaCols        interface{} `json:"textarea_cols"`
-					TextareaRows        interface{} `json:"textarea_rows"`
-					UserID              string      `json:"user_id"`
-					ValidFrom           string      `json:"valid_from"`
-					Width               interface{} `json:"width"`
-					WorkflowID          interface{} `json:"workflow_id"`
-				} `json:"1"`
-			} `json:"attributeList"`
-			Breadcrumbs []struct {
-				CreateButtonDescription interface{} `json:"create_button_description"`
-				CrumbType               string      `json:"crumbType"`
-				DefaultAttributeID      string      `json:"default_attribute_id"`
-				DefaultProjectID        string      `json:"default_project_id"`
-				DefaultSortAttributeID  string      `json:"default_sort_attribute_id"`
-				Description             string      `json:"description"`
-				Icon                    interface{} `json:"icon"`
-				ID                      string      `json:"id"`
-				IsActive                string      `json:"is_active"`
-				IsAttributeAttach       string      `json:"is_attribute_attach"`
-				IsCiAttach              string      `json:"is_ci_attach"`
-				IsDefaultSortAsc        string      `json:"is_default_sort_asc"`
-				IsEventEnabled          string      `json:"is_event_enabled"`
-				IsTabEnabled            string      `json:"is_tab_enabled"`
-				Name                    string      `json:"name"`
-				Note                    string      `json:"note"`
-				OrderNumber             string      `json:"order_number"`
-				ParentCiTypeID          string      `json:"parent_ci_type_id"`
-				Query                   interface{} `json:"query"`
-				Tag                     interface{} `json:"tag"`
-				UserID                  string      `json:"user_id"`
-				ValidFrom               string      `json:"valid_from"`
-			} `json:"breadcrumbs"`
-			CiList []struct {
-				Color             interface{} `json:"color"`
-				EmpEmailAddress   string      `json:"emp_email_address"`
-				EmpEmailAddressID string      `json:"emp_email_addressID"`
-				EmpFirstname      string      `json:"emp_firstname"`
-				EmpFirstnameID    string      `json:"emp_firstnameID"`
-				EmpLastname       string      `json:"emp_lastname"`
-				EmpLastnameID     string      `json:"emp_lastnameID"`
-				EmpStaffNumber    string      `json:"emp_staff_number"`
-				EmpStaffNumberID  string      `json:"emp_staff_numberID"`
-				ID                string      `json:"id"`
-			} `json:"ciList"`
-			CiTypeAttach            string      `json:"ciTypeAttach"`
-			CreateButtonDescription interface{} `json:"createButtonDescription"`
-			DefaultOrderBy          interface{} `json:"defaultOrderBy"`
-			IsQuery                 bool        `json:"isQuery"`
-			ListEdit                string      `json:"listEdit"`
-			Paginator               struct{}    `json:"paginator"`
-			Scrollbar               bool        `json:"scrollbar"`
-			TypeName                string      `json:"typeName"`
-		} `json:"data"`
-	} `json:"data"`
-	Message string `json:"message"`
-	Success bool   `json:"success"`
-}
-
 func (i *InfoCMDB) CiListByCiTypeID(ciTypeID int, out interface{}) (err error) {
-	params := map[string]string{
-		"ciTypeId":             fmt.Sprintf("%d", ciTypeID),
-		"XDEBUG_SESSION":       "XDEBUG_ECLIPSE",
-		"XDEBUG_SESSION_START": "XDEBUG_ECLIPSE",
-	}
-	err = i.Client.Get("/apiV2/ci/index", &out, params)
+	req := i.Client.NewRequest().
+		SetResult(&out).
+		SetQueryParams(map[string]string{
+			"ciTypeId": fmt.Sprintf("%d", ciTypeID),
+		})
+
+	_, err = req.Get("/apiV2/ci")
 
 	fmt.Printf("Message: %v\n", out)
 	if err != nil {
@@ -285,12 +200,18 @@ type GetCiResponse struct {
 	} `json:"data"`
 }
 
-func (i *InfoCMDB) CiDetailByCiId(ciId int64) (resp GetCiResponse, err error) {
-	params := map[string]string{
-		"id": strconv.FormatInt(ciId, 10),
+func (i *InfoCMDB) CiDetailByCiId(ciId int64) (resp GetCiResponse, restyRes *resty.Response, err error) {
+	if err = i.Login(); err != nil {
+		return
 	}
 
-	err = i.Client.Get("/apiV2/ci", &resp, params)
+	req := i.Client.NewRequest().
+		SetResult(&resp).
+		SetQueryParams(map[string]string{
+			"id": strconv.FormatInt(ciId, 10),
+		})
+
+	restyRes, err = req.Get("/apiV2/ci")
 
 	return
 }

--- a/core/v2/cmdb/client/client.go
+++ b/core/v2/cmdb/client/client.go
@@ -1,8 +1,7 @@
 package client
 
 import (
-	"errors"
-	"fmt"
+	"github.com/infonova/infocmdb-lib-go/core/v2/cmdb/models"
 	"gopkg.in/resty.v1"
 )
 
@@ -17,74 +16,13 @@ func NewClient(baseURL string) (c *Client) {
 	return
 }
 
-type ErrorReturn struct {
-	Message string      `json:"message"`
-	Success bool        `json:"success"`
-	Data    interface{} `json:"data,omitempty"`
-}
+func (i *Client) NewRequest() *resty.Request {
+	r := i.resty.R().
+		SetError(models.ErrorReturn{})
 
-const MethodPostForm = "POST_FORM"
+	return r
+}
 
 func (i *Client) SetAuthToken(token string) {
 	i.resty.SetAuthToken(token)
-}
-func (i *Client) SetHostURL(token string) {
-	i.resty.SetHostURL(token)
-}
-
-func (i *Client) Execute(method string, url string, out interface{}, params map[string]string) (err error) {
-	rest := i.resty.R().
-		SetResult(&out).
-		SetError(ErrorReturn{})
-
-	switch method {
-	case resty.MethodGet:
-		rest.SetQueryParams(params)
-	case MethodPostForm:
-		rest.SetFormData(params)
-		method = resty.MethodPost
-	default:
-		rest.SetBody(params) // json encoded body
-	}
-
-	resp, err := rest.Execute(method, url)
-
-	if err != nil {
-		err = errors.New(fmt.Sprintf("failed to send %s request to %s: %s", method, url, err.Error()))
-		return
-	}
-
-	// HTTP status code >= 400
-	if resp.IsError() {
-		errResp := resp.Error().(*ErrorReturn)
-		err = errors.New(errResp.Message)
-		return
-	}
-
-	// "out" will be set in resty
-	return
-}
-
-func (i *Client) Get(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(resty.MethodGet, url, out, params)
-}
-
-func (i *Client) Post(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(resty.MethodPost, url, out, params)
-}
-
-func (i *Client) PostForm(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(MethodPostForm, url, out, params)
-}
-
-func (i *Client) Put(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(resty.MethodPut, url, out, params)
-}
-
-func (i *Client) Delete(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(resty.MethodDelete, url, out, params)
-}
-
-func (i *Client) Patch(url string, out interface{}, params map[string]string) (err error) {
-	return i.Execute(resty.MethodPatch, url, out, params)
 }

--- a/core/v2/cmdb/login.go
+++ b/core/v2/cmdb/login.go
@@ -36,9 +36,11 @@ func (i *InfoCMDB) Login() (err error) {
 		i.Client = client.NewClient(i.Config.Url)
 	}
 
-	i.Client.SetHostURL(i.Config.Url)
+	req := i.Client.NewRequest().
+		SetResult(&loginResult).
+		SetFormData(params)
 
-	err = i.Client.PostForm("/apiV2/auth/token", &loginResult, params)
+	_, err = req.Post("/apiV2/auth/token")
 	if err != nil {
 		err = errors.New("Failed to fetch token: " + err.Error())
 		return

--- a/core/v2/cmdb/query.go
+++ b/core/v2/cmdb/query.go
@@ -1,9 +1,31 @@
 package cmdb
 
-func (i *InfoCMDB) Query(query string, out interface {}, params map[string]string) (err error) {
+import "gopkg.in/resty.v1"
+
+type queryParams struct {
+	Params map[string]string `json:"params"`
+}
+
+type queryRequest struct {
+	Query queryParams `json:"query"`
+}
+
+func (i *InfoCMDB) Query(query string, out interface{}, params map[string]string) (resp *resty.Response, err error) {
 	if err = i.Login(); err != nil {
 		return
 	}
 
-	return i.Client.Put("/apiV2/query", &out, params)
+	r := queryRequest{
+		Query: queryParams{
+			Params: params,
+		},
+	}
+
+	req := i.Client.NewRequest().
+		SetResult(out).
+		SetBody(r)
+
+	resp, err = req.Put("/apiV2/query/execute/" + query)
+
+	return
 }

--- a/core/v2/cmdb/query_test.go
+++ b/core/v2/cmdb/query_test.go
@@ -35,7 +35,7 @@ func TestInfoCMDB_Query(t *testing.T) {
 				Client: client.NewClient(tt.fields.Config.Url),
 				Error:  tt.fields.Error,
 			}
-			if err := i.Query(tt.args.query, tt.args.out, tt.args.params); (err != nil) != tt.wantErr {
+			if _, err := i.Query(tt.args.query, tt.args.out, tt.args.params); (err != nil) != tt.wantErr {
 				t.Errorf("InfoCMDB.Query() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
Because cmdb api requests are structured with nested data, the current concept with string maps does not make sense.
Instead a new function "NewRequest" can be used to standardize requests.
Later the "OnAfterResponse" of resty can be used to add central error handling.