### PR TITLE
webservice error enhancements

### DIFF
--- a/infocmdb/v1/cmdb/webservice.go
+++ b/infocmdb/v1/cmdb/webservice.go
@@ -129,6 +129,7 @@ func (i *Cmdb) CallWebservice(method string, service string, serviceName string,
 
 	err = checkResponseStatusMessage(byteBody)
 	if err != nil {
+		err = errors.New(err.Error() + ": " + string(byteBody))
 		return err
 	}
 

--- a/infocmdb/v1/cmdb/webservice.go
+++ b/infocmdb/v1/cmdb/webservice.go
@@ -140,8 +140,7 @@ func (i *Cmdb) CallWebservice(method string, service string, serviceName string,
 
 	err = json.Unmarshal([]byte(byteBody), &variable)
 	if err != nil {
-		log.Error("Error: ", err)
-		log.Error(string(byteBody))
+		err = errors.New(err.Error() + ": " + string(byteBody))
 		return err
 	}
 	return nil


### PR DESCRIPTION
Bundled error enhancements in the webservice module:
* prevent duplicate error logging 
* add response body to CallWebservice error

### prevent duplicate error logging

Remove log.Error statements before returning an error.
This lets the consumer of the function decide if the error should be logged
and were it should be logged to.

Previously some code paths also logged the error before returning it
while others didn't, making it impossible to always log errors but prevent duplicates.

### add response body to CallWebservice error

When a Webservice call fails the response body is included in the error message.

The response may include a more detailed error message
and thus help to identify the root cause.