### PR TITLE
Remove ListOfCiIds wrapper

### DIFF
--- a/infocmdb/webservice_default.go
+++ b/infocmdb/webservice_default.go
@@ -47,20 +47,20 @@ func (c *Client) Query(ws string, out interface{}, params map[string]string) (er
 	return
 }
 
-type ListOfCiIds []struct {
-	CiID int `json:"ciid,string"`
-}
+type CiIds []int
 
 type GetListOfCiIdsOfCiType struct {
-	Status string      `json:"status"`
-	Data   ListOfCiIds `json:"data"`
+	Status string `json:"status"`
+	Data   []struct {
+		CiID int `json:"ciid,string"`
+	} `json:"data"`
 }
 
 type ResponseId struct {
 	Id int `json:"id,string"`
 }
 
-func (c *Client) GetListOfCiIdsOfCiType(ciTypeID int) (r ListOfCiIds, err error) {
+func (c *Client) GetListOfCiIdsOfCiType(ciTypeID int) (ciIds CiIds, err error) {
 
 	if err = c.v2.Login(); err != nil {
 		return
@@ -78,13 +78,17 @@ func (c *Client) GetListOfCiIdsOfCiType(ciTypeID int) (r ListOfCiIds, err error)
 	err = c.v2.Query("int_getListOfCiIdsOfCiType", &ret, params)
 	if err != nil {
 		log.Error("Error: ", err)
-		return r, err
+		return ciIds, err
 	}
-	r = ret.Data
+
+	for _, ciIdOfCiType := range ret.Data {
+		ciIds = append(ciIds, ciIdOfCiType.CiID)
+	}
+
 	return
 }
 
-func (c *Client) GetListOfCiIdsOfCiTypeV2(ciTypeID int) (r ListOfCiIds, err error) {
+func (c *Client) GetListOfCiIdsOfCiTypeV2(ciTypeID int) (ciIds CiIds, err error) {
 
 	if err = c.v2.Login(); err != nil {
 		return
@@ -102,13 +106,17 @@ func (c *Client) GetListOfCiIdsOfCiTypeV2(ciTypeID int) (r ListOfCiIds, err erro
 	err = c.v2.Query("int_getListOfCiIdsOfCiType", &ret, params)
 	if err != nil {
 		log.Error("Error: ", err)
-		return r, err
+		return ciIds, err
 	}
-	r = ret.Data
+
+	for _, ciIdOfCiType := range ret.Data {
+		ciIds = append(ciIds, ciIdOfCiType.CiID)
+	}
+
 	return
 }
 
-func (c *Client) GetListOfCiIdsOfCiTypeName(ciTypeName string) (r ListOfCiIds, err error) {
+func (c *Client) GetListOfCiIdsOfCiTypeName(ciTypeName string) (ciIds CiIds, err error) {
 
 	if err = c.v2.Login(); err != nil {
 		return
@@ -120,16 +128,18 @@ func (c *Client) GetListOfCiIdsOfCiTypeName(ciTypeName string) (r ListOfCiIds, e
 		return
 	}
 
-	r, err = c.GetListOfCiIdsOfCiType(ciTypeId)
+	ciIds, err = c.GetListOfCiIdsOfCiType(ciTypeId)
 	return
 }
 
 type GetListOfCiIdsByAttributeValue struct {
-	Status string      `json:"status"`
-	Data   ListOfCiIds `json:"data"`
+	Status string `json:"status"`
+	Data   []struct {
+		CiID int `json:"ciid,string"`
+	} `json:"data"`
 }
 
-func (c *Client) GetListOfCiIdsByAttributeValue(att, value string, field v1.AttributeValueType) (r ListOfCiIds, err error) {
+func (c *Client) GetListOfCiIdsByAttributeValue(att, value string, field v1.AttributeValueType) (ciIds CiIds, err error) {
 
 	if err = c.v2.Login(); err != nil {
 		return
@@ -150,9 +160,13 @@ func (c *Client) GetListOfCiIdsByAttributeValue(att, value string, field v1.Attr
 	err = c.v1.CallWebservice(http.MethodPost, "query", "int_getCiIdByCiAttributeValue", params, &ret)
 	if err != nil {
 		log.Error("Error: ", err)
-		return r, err
+		return ciIds, err
 	}
-	r = ret.Data
+
+	for _, ciIdOfCiType := range ret.Data {
+		ciIds = append(ciIds, ciIdOfCiType.CiID)
+	}
+
 	return
 }
 

--- a/infocmdb/webservice_default_test.go
+++ b/infocmdb/webservice_default_test.go
@@ -42,7 +42,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiType(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		wantR   ListOfCiIds
+		wantR   CiIds
 		wantErr bool
 	}{
 		{
@@ -72,7 +72,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiType(t *testing.T) {
 				}},
 			},
 			args{ciTypeID: 1},
-			ListOfCiIds{{1}, {2}},
+			CiIds{1, 2},
 			false,
 		},
 		{
@@ -121,7 +121,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiTypeV2(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		wantR   ListOfCiIds
+		wantR   CiIds
 		wantErr bool
 	}{
 		{
@@ -151,7 +151,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiTypeV2(t *testing.T) {
 				}},
 			},
 			args{ciTypeID: 1},
-			ListOfCiIds{{1}, {2}},
+			CiIds{1, 2},
 			false,
 		},
 		{


### PR DESCRIPTION
The ListOfCiIds was just a simple array of structs with the CiId in it
(mapped variant of the json response).
This made the use in the infoCMDB workflows slightly awkward:
```go
cidIds, err := cmdb.GetListOfCiIdsOfCiTypeName("...")
// omitted error handling...

for _, ciId := range cidIds {
	// do something with ciId.CiID
}
```
This commit simplifies the workflow usage by removing this wrapper:
```go
cidIds, err := cmdb.GetListOfCiIdsOfCiTypeName("...")
// omitted error handling...

for _, ciId := range cidIds {
	// do something with ciId directly
}
```