### PR TITLE
fix config file loading in v1 client

### DIFF
--- a/infocmdb/v1/cmdb/cmdb.go
+++ b/infocmdb/v1/cmdb/cmdb.go
@@ -66,7 +66,7 @@ func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 	if err == nil {
 		log.Debugf("ConfigFile found with given string: %s", configFile)
 	} else {
-		WorkflowConfigPath := filepath.Dir(os.Getenv("WORKFLOW_CONFIG_PATH"))
+		WorkflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
 		log.Debugf("WORKFLOW_CONFIG_PATH: %s", WorkflowConfigPath)
 		configFile = filepath.Join(WorkflowConfigPath, configFile)
 	}


### PR DESCRIPTION
Use the WORKFLOW_CONFIG_PATH env variable without passing it to filepath.Dir(...)
to prevent removing the last path element (similar to v2 client config file loading).