### PR TITLE
updates log output, format and messages

### DIFF
--- a/infocmdb/infocmdb.go
+++ b/infocmdb/infocmdb.go
@@ -14,6 +14,7 @@ package infocmdb
 // This api properly handles all permission checks and access to native functions.
 
 import (
+	"bytes"
 	v1 "github.com/infonova/infocmdb-sdk-go/infocmdb/v1/infocmdb"
 	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 	log "github.com/sirupsen/logrus"
@@ -37,7 +38,21 @@ type Client struct {
 	v2 *v2.Cmdb
 }
 
+type logOutputSplitter struct{}
+
+func (splitter *logOutputSplitter) Write(msg []byte) (n int, err error) {
+	if bytes.HasPrefix(msg, []byte("[TRACE]")) ||
+		bytes.HasPrefix(msg, []byte("[DEBUG]")) ||
+		bytes.HasPrefix(msg, []byte("[INFO]")) {
+		return os.Stdout.Write(msg)
+	}
+	return os.Stderr.Write(msg)
+}
+
 func init() {
+	// Log to stdout and stderr depending on log level:
+	// Any message on stderr is interpreted as workflow failure
+	log.SetOutput(&logOutputSplitter{})
 	// Time is omitted in the log message, because it is already shown in the workflow log in a separate column
 	log.SetFormatter(&easy.Formatter{
 		LogFormat: "[%lvl%] %msg%\n",

--- a/infocmdb/infocmdb.go
+++ b/infocmdb/infocmdb.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/infonova/infocmdb-sdk-go/infocmdb/v1/infocmdb"
 	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 	log "github.com/sirupsen/logrus"
+	easy "github.com/t-tomalak/logrus-easy-formatter"
 	"os"
 )
 
@@ -37,6 +38,10 @@ type Client struct {
 }
 
 func init() {
+	// Time is omitted in the log message, because it is already shown in the workflow log in a separate column
+	log.SetFormatter(&easy.Formatter{
+		LogFormat: "[%lvl%] %msg%\n",
+	})
 	log.SetLevel(log.InfoLevel)
 	if os.Getenv("WORKFLOW_DEBUGGING") == "true" {
 		log.SetLevel(log.DebugLevel)

--- a/infocmdb/v1/infocmdb/cmdb.go
+++ b/infocmdb/v1/infocmdb/cmdb.go
@@ -53,13 +53,6 @@ const (
 	ATTRIBUTE_VALUE_TYPE_CI                         = "value_ci"
 )
 
-func init() {
-	log.SetLevel(log.InfoLevel)
-	if os.Getenv("WORKFLOW_DEBUGGING") == "true" {
-		log.SetLevel(log.DebugLevel)
-	}
-}
-
 func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 	_, err = os.Stat(configFile)
 	if err == nil {

--- a/infocmdb/v1/infocmdb/cmdb.go
+++ b/infocmdb/v1/infocmdb/cmdb.go
@@ -97,7 +97,7 @@ func New(config string) (i *Cmdb, err error) {
 
 func (i *Cmdb) Login() error {
 	if i.Config.ApiKey != "" {
-		log.Debug("already logged in")
+		log.Trace("already logged in")
 		return nil
 	}
 

--- a/infocmdb/v1/infocmdb/cmdb.go
+++ b/infocmdb/v1/infocmdb/cmdb.go
@@ -58,12 +58,11 @@ func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 	if err == nil {
 		log.Debugf("ConfigFile found with given string: %s", configFile)
 	} else {
-		WorkflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
-		log.Debugf("WORKFLOW_CONFIG_PATH: %s", WorkflowConfigPath)
-		configFile = filepath.Join(WorkflowConfigPath, configFile)
+		workflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
+		configFile = filepath.Join(workflowConfigPath, configFile)
 	}
 
-	log.Debugf("ConfigFile: %s", configFile)
+	log.Debugf("Loading workflow config file for v1 client: %s", configFile)
 
 	_, err = os.Stat(configFile)
 	if err != nil {
@@ -79,7 +78,15 @@ func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 }
 
 func (i *Cmdb) LoadConfig(config []byte) (err error) {
-	return yaml.Unmarshal(config, &i.Config)
+	log.Tracef("Config file content:\n%s", config)
+
+	err = yaml.Unmarshal(config, &i.Config)
+	if err != nil {
+		return
+	}
+
+	log.Debugf("Config: %+v", i.Config)
+	return
 }
 
 func New(config string) (i *Cmdb, err error) {

--- a/infocmdb/v2/infocmdb/cmdb.go
+++ b/infocmdb/v2/infocmdb/cmdb.go
@@ -63,13 +63,6 @@ const (
 	UPDATE_MODE_SET               = "set"
 )
 
-func init() {
-	log.SetLevel(log.InfoLevel)
-	if os.Getenv("WORKFLOW_DEBUGGING") == "true" {
-		log.SetLevel(log.DebugLevel)
-	}
-}
-
 func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 	_, err = os.Stat(configFile)
 	if os.IsNotExist(err) {

--- a/infocmdb/v2/infocmdb/cmdb.go
+++ b/infocmdb/v2/infocmdb/cmdb.go
@@ -66,14 +66,13 @@ const (
 func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 	_, err = os.Stat(configFile)
 	if os.IsNotExist(err) {
-		WorkflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
-		log.Debugf("WORKFLOW_CONFIG_PATH: %s", WorkflowConfigPath)
-		configFile = filepath.Join(WorkflowConfigPath, configFile)
+		workflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
+		configFile = filepath.Join(workflowConfigPath, configFile)
 	} else if err != nil {
 		return
 	}
 
-	log.Debugf("ConfigFile: %s", configFile)
+	log.Debugf("Loading workflow config file for v2 client: %s", configFile)
 
 	_, err = os.Stat(configFile)
 	if err != nil {
@@ -90,6 +89,9 @@ func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
 }
 
 func (i *Cmdb) LoadConfig(config []byte) (err error) {
+	log.Tracef("Config file content:\n%s", config)
+
+	err = yaml.Unmarshal(config, &i.Config)
 	if err = yaml.Unmarshal(config, &i.Config); err != nil {
 		return
 	}
@@ -99,6 +101,7 @@ func (i *Cmdb) LoadConfig(config []byte) (err error) {
 		return
 	}
 
+	log.Debugf("Config: %+v", i.Config)
 	i.Client = client.New(i.Config.Url)
 	return
 }

--- a/infocmdb/v2/infocmdb/login.go
+++ b/infocmdb/v2/infocmdb/login.go
@@ -17,7 +17,7 @@ type LoginTokenReturn struct {
 func (i *Cmdb) Login() (err error) {
 
 	if i.Config.ApiKey != "" {
-		log.Debug("already logged in")
+		log.Trace("already logged in")
 		return nil
 	}
 	if i.Config.Username == "" || i.Config.Password == "" {

--- a/infocmdb/v2/infocmdb/query.go
+++ b/infocmdb/v2/infocmdb/query.go
@@ -2,6 +2,7 @@ package infocmdb
 
 import (
 	"github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb/client"
+	log "github.com/sirupsen/logrus"
 )
 
 type queryParams struct {
@@ -13,6 +14,8 @@ type queryRequest struct {
 }
 
 func (i *Cmdb) Query(query string, out interface{}, params map[string]string) (err error) {
+	log.Debugf("Querying webservice %v with params %v", query, params)
+
 	if err = i.Login(); err != nil {
 		return
 	}
@@ -33,9 +36,11 @@ func (i *Cmdb) Query(query string, out interface{}, params map[string]string) (e
 		Put("/apiV2/query/execute/" + query)
 
 	if resp != nil && resp.IsError() {
+		log.Debugf("Error result: %v", respError)
 		return respError
 	}
 
+	log.Debugf("Result: %v", out)
 	return
 }
 

--- a/infocmdb/webservice_default.go
+++ b/infocmdb/webservice_default.go
@@ -20,6 +20,8 @@ import (
 // QueryWebservices allows you to call a generic webservice(arg1: ws) with the providing params
 // Return: json string
 func (c *Client) QueryWebservice(ws string, params map[string]string) (resp string, err error) {
+	log.Debugf("Querying webservice %v with params %v", ws, params)
+
 	if err = c.v2.Login(); err != nil {
 		return
 	}
@@ -29,6 +31,7 @@ func (c *Client) QueryWebservice(ws string, params map[string]string) (resp stri
 		log.Error("Error: ", err)
 	}
 
+	log.Debugf("Result: %v", resp)
 	return
 }
 
@@ -36,6 +39,8 @@ func (c *Client) QueryWebservice(ws string, params map[string]string) (resp stri
 // to a result. It will take the built in resty function to deserialize the result
 // Return: error
 func (c *Client) Query(ws string, out interface{}, params map[string]string) (err error) {
+	log.Debugf("Querying webservice %v with params %v", ws, params)
+
 	if err = c.v2.Login(); err != nil {
 		return
 	}
@@ -44,6 +49,7 @@ func (c *Client) Query(ws string, out interface{}, params map[string]string) (er
 		log.Error("Error: ", err)
 	}
 
+	log.Debugf("Result: %v", out)
 	return
 }
 


### PR DESCRIPTION
There are quite a few changes here packed together. They all have something to do with logging.
The most controversial ones are IMO the change to the log output and the change to the log formatter.
Please review every commit separately.
I can always change the commits individually or skip them entirely if you wish.

###  removes redundant logger setup in different packages

I am not quite sure why this was duplicated. My testing showed that these can simply be removed. 
Hope I haven't missed something...

###  changes log level of "already logged in" message to trace

I've made this change to remove some spam on debug level.

### adds simple debug logs for webservice calls

Probably self explaining.
Name and parameters for cmdb webservice calls are logged on debug level.

Example output:
```log
time="..." level=debug msg="Querying webservice int_getListOfCiIdsOfCiType with params map[argv1:13]"
time="..." level=debug msg="Result: &{ [{5854} {5855} {5856} {5857} {5858} {5860} {5861} {5862} {5863} {5864} {5865} {5866} {5867} {5868} {5869} {5870} {5871} {5872} {5873} {5874} {5875} {5876} {5877} {5878} {5879} {5880} {5881} {5882} {5883} {5884}]}"
```

### configures log formatter

... for better consistency with the current workflow output.

Example:
```log
2019-11-21 10:41:03 | process Workflow Item
2019-11-21 10:41:03 | Environment: export  APPLICATION_ENV="development" APPLICATION_PATH="/app/application"  APPLICATION_URL="http://infocmdb.local/" APPLICATION_DATA="/app/data"  APPLICATION_PUBLIC="/app/public/"  WORKFLOW_CONFIG_PATH="/app/data/configs/workflows"  WORKFLOW_DEBUGGING="true"
2019-11-21 10:41:03 | executing script  "/app/data/workflows/golang/upd_relations_res_github_repo__res_github_org//upd_relations_res_github_repo__res_github_org   '{"apikey":"0b68eaac1b78b516c4db94df5d5474","triggerType":"manual","user_id":"1","workflow_item_id":27515,"workflow_instance_id":27515}'"
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Loading workflow config file for v1 client: /app/data/configs/workflows/infocmdb.yml
2019-11-21 10:41:03 | [SCRIPT] [DEBUG]  Config: {ApiUrl:http://infoCMDB.local/ ApiUser:ext_webservice  ApiPassword:ZTExNzU1NmFkMjgwZTliNmFkZmExMmIxNDRjZWY2 ApiKey:  CmdbBasePath:/app/}
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Loading workflow config file for v2 client: /app/data/configs/workflows/infocmdb.yml
2019-11-21 10:41:03 | [SCRIPT] [DEBUG]  Config: {Url:http://infoCMDB.local/ Username:ext_webservice  Password:ZTExNzU1NmFkMjgwZTliNmFkZmExMmIxNDRjZWY2 ApiKey: BasePath:}
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Opening new WebClient connection. (Url: http://infoCMDB.local/, Username: ext_webservice)
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Querying webservice int_getListOfCiIdsOfCiType with params map[argv1:13]
2019-11-21 10:41:03 | [SCRIPT] [DEBUG]  Result: &{ [{5854} {5855} {5856} {5857} {5858} {5860} {5861} {5862}  {5863} {5864} {5865} {5866} {5867} {5868} {5869} {5870} {5871} {5872}  {5873} {5874} {5875} {5876} {5877} {5878} {5879} {5880} {5881} {5882}  {5883} {5884}]}
```

###  configures log output

Everything below log level warn is logged to stdout
and everything from log level warn and above is logged to stderr
to indicate a workflow failure.

I am not sure if this separation is a good idea. It proved useful in a custom workflow I have written, but it might be surprising behavior. Let me know what you think.

###  updates logging of workflow config file loading 

Shows the raw config file content on trace level and the loaded file path and final config on debug level.

Example with debug level:
```log
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Loading workflow config file for v1 client: /app/data/configs/workflows/infocmdb.yml
2019-11-21 10:41:03 | [SCRIPT] [DEBUG]  Config: {ApiUrl:http://infoCMDB.local/ ApiUser:ext_webservice  ApiPassword:ZTExNzU1NmFkMjgwZTliNmFkZmExMmIxNDRjZWY2 ApiKey:  CmdbBasePath:/app/}
2019-11-21 10:41:03 | [SCRIPT] [DEBUG] Loading workflow config file for v2 client: /app/data/configs/workflows/infocmdb.yml
2019-11-21 10:41:03 | [SCRIPT] [DEBUG]  Config: {Url:http://infoCMDB.local/ Username:ext_webservice  Password:ZTExNzU1NmFkMjgwZTliNmFkZmExMmIxNDRjZWY2 ApiKey: BasePath:}
```