### PR TITLE
extracts yaml config loading to public function

### DIFF
--- a/infocmdb/config/config.go
+++ b/infocmdb/config/config.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Loads a workflow configuration file.
+//
+// If the given path is a absolute path to an existing file,
+// it will be read and parsed in yaml format into the given config output parameter.
+// If it is a relative path instead, the config path will be resolved using the WORKFLOW_CONFIG_PATH env variable.
+func LoadYamlConfig(path string, config interface{}) (err error) {
+	path, err = resolveAbsoluteConfigFilePath(path)
+	if err != nil {
+		return
+	}
+
+	return parseYamlConfig(path, config)
+}
+
+func resolveAbsoluteConfigFilePath(path string) (string, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		workflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
+		path = filepath.Join(workflowConfigPath, path)
+	} else if err != nil {
+		return "", err
+	}
+
+	log.Debugf("Loading workflow config file: %s", path)
+
+	_, err = os.Stat(path)
+	return path, err
+}
+
+func parseYamlConfig(path string, config interface{}) (err error) {
+	configBytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	log.Tracef("Config file content:\n%s", configBytes)
+
+	err = yaml.Unmarshal(configBytes, config)
+	if err != nil {
+		return
+	}
+
+	log.Debugf("Config: %+v", config)
+	return
+}

--- a/infocmdb/v1/infocmdb/cmdb.go
+++ b/infocmdb/v1/infocmdb/cmdb.go
@@ -2,14 +2,11 @@ package infocmdb
 
 import (
 	"errors"
-	"io/ioutil"
-	"os"
-	"path/filepath"
+	"github.com/infonova/infocmdb-sdk-go/infocmdb/config"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -53,39 +50,8 @@ const (
 	ATTRIBUTE_VALUE_TYPE_CI                         = "value_ci"
 )
 
-func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
-	_, err = os.Stat(configFile)
-	if err == nil {
-		log.Debugf("ConfigFile found with given string: %s", configFile)
-	} else {
-		workflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
-		configFile = filepath.Join(workflowConfigPath, configFile)
-	}
-
-	log.Debugf("Loading workflow config file for v1 client: %s", configFile)
-
-	_, err = os.Stat(configFile)
-	if err != nil {
-		return
-	}
-
-	yamlFile, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return
-	}
-
-	return i.LoadConfig(yamlFile)
-}
-
-func (i *Cmdb) LoadConfig(config []byte) (err error) {
-	log.Tracef("Config file content:\n%s", config)
-
-	err = yaml.Unmarshal(config, &i.Config)
-	if err != nil {
-		return
-	}
-
-	log.Debugf("Config: %+v", i.Config)
+func (i *Cmdb) LoadConfigFile(path string) (err error) {
+	err = config.LoadYamlConfig(path, &i.Config)
 	return
 }
 

--- a/infocmdb/v1/infocmdb/cmdb_test.go
+++ b/infocmdb/v1/infocmdb/cmdb_test.go
@@ -10,25 +10,12 @@ import (
 	utilTesting "github.com/infonova/infocmdb-sdk-go/util/testing"
 )
 
-var (
-	infoCMDBConfig = []byte(`apiUrl: http://nginx/
-apiUser: admin
-apiPassword: admin
-CmdbBasePath: /app/`)
-	infoCMDBConfigFile = "test/test.yml"
-)
-
 func ExampleWebservice_Webservice() {
 
-	i, err := New(infoCMDBConfigFile)
-	if err != nil {
-		log.Error(ErrFailedToCreateInfoCMDB)
-		return
-	}
+	cmdb := Cmdb{}
+	utilTesting.New().SetValidConfig(&cmdb.Config)
 
-	i.Config.ApiUrl = utilTesting.New().GetUrl()
-
-	err = i.Login()
+	err := cmdb.Login()
 	if err != nil {
 		log.Error(err)
 		return
@@ -36,7 +23,7 @@ func ExampleWebservice_Webservice() {
 
 	params := url.Values{}
 	params.Add("argv1", "1")
-	ret, err := i.Webservice("int_getListOfCiIdsOfCiType", params)
+	ret, err := cmdb.Webservice("int_getListOfCiIdsOfCiType", params)
 	if err != nil {
 		log.Error(err)
 		return
@@ -45,34 +32,6 @@ func ExampleWebservice_Webservice() {
 
 	// Output:
 	// Return: {"status":"OK","data":[{"ciid":"1"},{"ciid":"2"}]}
-}
-
-func ExampleInfoCmdbGoLib_LoadConfigAbsolutePath() {
-	i := Cmdb{}
-	err := i.LoadConfig(infoCMDBConfig)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		return
-	}
-	fmt.Printf("Config: %v\n", i.Config)
-	fmt.Printf("BasePath: %s\n", i.Config.CmdbBasePath)
-	// Output:
-	// Config: {http://nginx/ admin admin  /app/}
-	// BasePath: /app/
-}
-
-func ExampleInfoCmdbGoLib_LoadConfig() {
-	i := Cmdb{}
-	err := i.LoadConfig(infoCMDBConfig)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		return
-	}
-	fmt.Printf("Config: %v\n", i.Config)
-	fmt.Printf("BasePath: %s\n", i.Config.CmdbBasePath)
-	// Output:
-	// Config: {http://nginx/ admin admin  /app/}
-	// BasePath: /app/
 }
 
 func ExampleInfoCmdbGoLib_LoadConfig_Fail() {
@@ -91,52 +50,32 @@ func ExampleInfoCmdbGoLib_LoadConfig_Fail() {
 
 func ExampleCmdbWebClient_Login() {
 
-	i, err := New(infoCMDBConfigFile)
-	if i == nil {
-		log.Error(ErrFailedToCreateInfoCMDB)
-		return
-	}
+	cmdb := Cmdb{}
+	utilTesting.New().SetValidConfig(&cmdb.Config)
 
-	i.Config.ApiUrl = utilTesting.New().GetUrl()
-	i.Config.ApiKey = ""
-
-	err = i.Login()
+	err := cmdb.Login()
 	if err != nil {
 		log.Error(err)
 		return
 	}
 
-	fmt.Printf("Login ok, ApiKey(len): %d\n", len(i.Config.ApiKey))
+	fmt.Printf("Login ok, ApiKey(len): %d\n", len(cmdb.Config.ApiKey))
 
 	// Output:
 	// Login ok, ApiKey(len): 30
 }
 func ExampleCmdbWebClient_LoginWithApiKey() {
 
-	ilogin, err := New(infoCMDBConfigFile)
+	cmdb := Cmdb{}
+	utilTesting.New().SetValidConfig(&cmdb.Config)
+
+	err := cmdb.Login()
 	if err != nil {
 		log.Error(err)
 		return
 	}
 
-	ilogin.Config.ApiUrl = utilTesting.New().GetUrl()
-	err = ilogin.Login()
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	log.Debugf("Got API Key: %s", ilogin.Config.ApiKey)
-	i, err := New(infoCMDBConfigFile)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	i.Config.ApiKey = ilogin.Config.ApiKey
-	i.Config.ApiUrl = utilTesting.New().GetUrl()
-
-	fmt.Printf("Login ok, ApiKey(len): %d\n", len(i.Config.ApiKey))
+	fmt.Printf("Login ok, ApiKey(len): %d\n", len(cmdb.Config.ApiKey))
 
 	// Output:
 	// Login ok, ApiKey(len): 30
@@ -144,24 +83,15 @@ func ExampleCmdbWebClient_LoginWithApiKey() {
 
 func ExampleCmdbWebClient_Post() {
 
-	i, err := New(infoCMDBConfigFile)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	i.Config.ApiUrl = utilTesting.New().GetUrl()
-	if i == nil {
-		log.Error(ErrFailedToCreateInfoCMDB)
-		return
-	}
+	cmdb := Cmdb{}
+	utilTesting.New().SetValidConfig(&cmdb.Config)
 
 	params := url.Values{
 		"argv1": {"1"},
 	}
 
 	ret := ""
-	err = i.CallWebservice(http.MethodPost, "query", "int_getListOfCiIdsOfCiType", params, &ret)
+	err := cmdb.CallWebservice(http.MethodPost, "query", "int_getListOfCiIdsOfCiType", params, &ret)
 	if err != nil {
 		log.Error(err)
 		return

--- a/infocmdb/v1/infocmdb/test/test.yml
+++ b/infocmdb/v1/infocmdb/test/test.yml
@@ -1,4 +1,0 @@
-apiUrl: http://nginx/
-apiUser: admin
-apiPassword: admin
-CmdbBasePath: /app/

--- a/infocmdb/v2/infocmdb/ci_test.go
+++ b/infocmdb/v2/infocmdb/ci_test.go
@@ -8,10 +8,9 @@ import (
 
 func TestInfoCMDB_CiListByCiTypeID(t *testing.T) {
 	ut := utilTesting.New()
-	configFile := utilTesting.BuildValidConfig(ut.GetUrl())
 	ut.AddMocking(utilTesting.Mocking{
 		RequestString: "GET##/apiV2/ci/index?ciTypeId=12##",
-		ReturnString:  `{
+		ReturnString: `{
     "success": true,
     "message": "success",
     "data": {
@@ -159,10 +158,7 @@ func TestInfoCMDB_CiListByCiTypeID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New()
-			e := c.LoadConfig(configFile)
-			if e != nil {
-				t.Fatal(e)
-			}
+			ut.SetValidConfig(&c.Config)
 
 			if err := c.Login(); err != nil {
 				t.Fatalf("Login failed: %v\n", err)

--- a/infocmdb/v2/infocmdb/cmdb.go
+++ b/infocmdb/v2/infocmdb/cmdb.go
@@ -2,17 +2,14 @@ package infocmdb
 
 import (
 	"errors"
-	"io/ioutil"
+	"github.com/infonova/infocmdb-sdk-go/infocmdb/config"
 	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb/client"
 	"github.com/patrickmn/go-cache"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
@@ -73,36 +70,9 @@ const (
 	UPDATE_MODE_SET               = "set"
 )
 
-func (i *Cmdb) LoadConfigFile(configFile string) (err error) {
-	_, err = os.Stat(configFile)
-	if os.IsNotExist(err) {
-		workflowConfigPath := os.Getenv("WORKFLOW_CONFIG_PATH")
-		configFile = filepath.Join(workflowConfigPath, configFile)
-	} else if err != nil {
-		return
-	}
-
-	log.Debugf("Loading workflow config file for v2 client: %s", configFile)
-
-	_, err = os.Stat(configFile)
+func (i *Cmdb) LoadConfigFile(path string) (err error) {
+	err = config.LoadYamlConfig(path, &i.Config)
 	if err != nil {
-		return
-	}
-
-	yamlFile, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return
-	}
-
-	err = i.LoadConfig(yamlFile)
-	return
-}
-
-func (i *Cmdb) LoadConfig(config []byte) (err error) {
-	log.Tracef("Config file content:\n%s", config)
-
-	err = yaml.Unmarshal(config, &i.Config)
-	if err = yaml.Unmarshal(config, &i.Config); err != nil {
 		return
 	}
 
@@ -111,7 +81,7 @@ func (i *Cmdb) LoadConfig(config []byte) (err error) {
 		return
 	}
 
-	log.Debugf("Config: %+v", i.Config)
+	log.Debugf("Config after applied url from redirect: %+v", i.Config)
 	i.Client = client.New(i.Config.Url)
 	return
 }


### PR DESCRIPTION
Moves duplicated code in v1 and v2 client config loading to separate package
that is also publicly accessible.
Internally uses the WORKFLOW_CONFIG_PATH env var to resolve relative paths.