### PR TITLE
Fix binding empty attribute value to empty []int

### DIFF
--- a/infocmdb/attribute_binding.go
+++ b/infocmdb/attribute_binding.go
@@ -98,6 +98,10 @@ func bindAttrToIntSliceField(attr CiAttribute, field reflect.Value) (err error) 
 
 	for _, value := range values {
 		trimmedValue := strings.TrimSpace(value)
+		if trimmedValue == "" {
+			continue
+		}
+
 		number, err := strconv.Atoi(trimmedValue)
 		if err != nil {
 			return &BindError{


### PR DESCRIPTION
Bug introduced with feature #56: Add function GetAndBindCiAttributes