### PR TITLE
Add more Ci and CiAttribute binding functions

### DIFF
--- a/infocmdb/attribute.go
+++ b/infocmdb/attribute.go
@@ -1,13 +1,18 @@
 package infocmdb
 
 import (
+	"errors"
+	"reflect"
 	"strconv"
+
+	utilCache "github.com/patrickmn/go-cache"
+	log "github.com/sirupsen/logrus"
 
 	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 	utilError "github.com/infonova/infocmdb-sdk-go/util/error"
-	utilCache "github.com/patrickmn/go-cache"
-	log "github.com/sirupsen/logrus"
 )
+
+type CiAttributes = []CiAttribute
 
 type CiAttribute struct {
 	CiID                 int    `json:"ci_id,string,string"`
@@ -24,13 +29,34 @@ type getCiAttributes struct {
 	Data []CiAttribute `json:"data"`
 }
 
-func (c *Client) GetCiAttributes(ciID int) (r []CiAttribute, err error) {
+func (c *Client) GetCiAttributes(ciId int) (ciAttributes CiAttributes, err error) {
+	ciIdToAttributesMap, err := c.GetMapOfCiAttributes([]int{ciId})
+	if err != nil {
+	    return
+	}
+
+	ciAttributes = ciIdToAttributesMap[ciId]
+	return
+}
+
+func (c *Client) GetMapOfCiAttributes(ciIds []int) (ciIdToAttributesMap map[int]CiAttributes, err error) {
+	ciIdToAttributesMap = map[int]CiAttributes{}
+
 	if err = c.v2.Login(); err != nil {
 		return
 	}
 
+	commaSeparatedCiIds := ""
+	for _, ciId := range ciIds {
+		if commaSeparatedCiIds != "" {
+			commaSeparatedCiIds += ", "
+		}
+
+		commaSeparatedCiIds += strconv.Itoa(ciId)
+	}
+
 	params := map[string]string{
-		"argv1": strconv.Itoa(ciID),
+		"argv1": commaSeparatedCiIds,
 	}
 
 	jsonRet := getCiAttributes{}
@@ -39,17 +65,59 @@ func (c *Client) GetCiAttributes(ciID int) (r []CiAttribute, err error) {
 		err = utilError.FunctionError(err.Error())
 		log.Error("Error: ", err)
 	}
-	r = jsonRet.Data
+
+	for _, ciAttribute := range jsonRet.Data {
+		ciAttributes, ok := ciIdToAttributesMap[ciAttribute.CiID]
+		if !ok {
+			ciAttributes = CiAttributes{}
+		}
+		ciAttributes = append(ciAttributes, ciAttribute)
+		ciIdToAttributesMap[ciAttribute.CiID] = ciAttributes
+	}
+
 	return
 }
 
-func (c *Client) GetAndBindCiAttributes(ciID int, out interface{}) (err error) {
-	attributes, err := c.GetCiAttributes(ciID)
+func (c *Client) GetAndBindCiAttributes(ciId int, out interface{}) (err error) {
+	attributes, err := c.GetCiAttributes(ciId)
 	if err != nil {
 		return
 	}
 
 	return bindCiAttributes(attributes, out)
+}
+
+func (c *Client) GetAndBindListOfCiAttributes(ciIds []int, out interface{}) (err error) {
+	ciIdToAttributesMap, err := c.GetMapOfCiAttributes(ciIds)
+	if err != nil {
+		return
+	}
+
+	outSlicePtr := reflect.ValueOf(out)
+	if outSlicePtr.Kind() != reflect.Ptr {
+		return errors.New("out parameter is not a slice pointer")
+	}
+	outSlice := outSlicePtr.Elem()
+	if outSlice.Kind() != reflect.Slice {
+		return errors.New("out parameter is not a slice pointer")
+	}
+	outSliceElem := reflect.TypeOf(outSlice.Interface()).Elem()
+	outSliceValue := reflect.MakeSlice(outSlice.Type(), 0, 0)
+
+	for _, ciId := range ciIds {
+		ciAttributes := ciIdToAttributesMap[ciId]
+
+		elem := reflect.New(outSliceElem)
+		err = bindCiAttributes(ciAttributes, elem.Interface())
+		if err != nil {
+			return
+		}
+
+		outSliceValue = reflect.Append(outSliceValue, elem.Elem())
+	}
+
+	outSlice.Set(outSliceValue)
+	return
 }
 
 type getAttributeDefaultOption struct {

--- a/infocmdb/attribute_binding.go
+++ b/infocmdb/attribute_binding.go
@@ -20,9 +20,11 @@ func (e *BindError) Error() string {
 }
 
 func bindCiAttributes(attributes []CiAttribute, out interface{}) (err error) {
-	attrNameToAttrMap := map[string]CiAttribute{}
+	attrNameToAttrMap := map[string][]CiAttribute{}
 	for _, attr := range attributes {
-		attrNameToAttrMap[attr.AttributeName] = attr
+		ciAttributes := attrNameToAttrMap[attr.AttributeName]
+		ciAttributes = append(ciAttributes, attr)
+		attrNameToAttrMap[attr.AttributeName] = ciAttributes
 	}
 
 	outValue := reflect.ValueOf(out)
@@ -34,28 +36,34 @@ func bindCiAttributes(attributes []CiAttribute, out interface{}) (err error) {
 		valueField := outValue.Field(i)
 
 		tag := structField.Tag.Get("attr")
-
 		if tag == "" || tag == "-" {
 			continue
 		}
 
-		attr := attrNameToAttrMap[tag]
+		attrs := attrNameToAttrMap[tag]
 
 		structFieldTypeName := structField.Type.String()
 		switch structFieldTypeName {
 		case "string":
-			valueField.SetString(attr.Value)
+			err = bindAttrToStringField(attrs, valueField)
+			if err != nil {
+				return
+			}
 		case "[]string":
-			err = bindAttrToStringSliceField(attr, valueField)
+			err = bindAttrToStringSliceField(attrs, valueField)
 			if err != nil {
 				return
 			}
 		case "[]int":
-			err = bindAttrToIntSliceField(attr, valueField)
+			err = bindAttrToIntSliceField(attrs, valueField)
 			if err != nil {
 				return
 			}
 		default:
+			var attr CiAttribute
+			if len(attrs) > 0 {
+				attr = attrs[0]
+			}
 			return &BindError{
 				Msg:       fmt.Sprintf("failed to map struct field %v of type %v", structField.Name, structFieldTypeName),
 				FieldName: structField.Name,
@@ -69,30 +77,63 @@ func bindCiAttributes(attributes []CiAttribute, out interface{}) (err error) {
 	return
 }
 
-func bindAttrToStringSliceField(attr CiAttribute, field reflect.Value) (err error) {
-	switch attr.AttributeType {
-	case "textarea":
-		values := strings.Split(attr.Value, "\n")
-
-		for i, value := range values {
-			values[i] = strings.TrimSpace(value)
-		}
-
-		field.Set(reflect.ValueOf(values))
-	default:
+func bindAttrToStringField(attrs []CiAttribute, field reflect.Value) (err error) {
+	if len(attrs) == 0 {
+		return
+	} else if len(attrs) == 1 {
+		field.SetString(attrs[0].Value)
+	} else {
+		attr := attrs[0]
 		return &BindError{
-			Msg:       fmt.Sprintf("failed to map attribute type %v to []string", attr.AttributeType),
+			Msg:       fmt.Sprintf("failed to map multiple attributes with name \"%v\" to string", attr.AttributeName),
 			FieldName: field.Type().Name(),
 			SrcName:   attr.AttributeName,
 			SrcType:   attr.AttributeType,
-			SrcValue:  attr.Value,
 		}
 	}
 
 	return
 }
 
-func bindAttrToIntSliceField(attr CiAttribute, field reflect.Value) (err error) {
+func bindAttrToStringSliceField(attrs []CiAttribute, field reflect.Value) (err error) {
+	if len(attrs) == 0 {
+		return
+	}
+
+	values := field.Interface().([]string)
+
+	for _, attr := range attrs {
+		switch attr.AttributeType {
+		case "input":
+			values = append(values, strings.TrimSpace(attr.Value))
+		case "textarea":
+			textareaValues := strings.Split(attr.Value, "\n")
+			for _, textareaValue := range textareaValues {
+				values = append(values, strings.TrimSpace(textareaValue))
+			}
+		default:
+			return &BindError{
+				Msg:       fmt.Sprintf("failed to map attribute type %v to []string", attr.AttributeType),
+				FieldName: field.Type().Name(),
+				SrcName:   attr.AttributeName,
+				SrcType:   attr.AttributeType,
+				SrcValue:  attr.Value,
+			}
+		}
+	}
+
+	field.Set(reflect.ValueOf(values))
+	return
+}
+
+func bindAttrToIntSliceField(attrs []CiAttribute, field reflect.Value) (err error) {
+	if len(attrs) == 0 {
+		return
+	}
+
+	// TODO: binding multiple attributes to int slice not implemented yet
+	attr := attrs[0]
+
 	var numbers []int
 	values := strings.Split(attr.Value, ",")
 

--- a/infocmdb/ci.go
+++ b/infocmdb/ci.go
@@ -6,9 +6,10 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 	utilError "github.com/infonova/infocmdb-sdk-go/util/error"
-	log "github.com/sirupsen/logrus"
 )
 
 type Ci struct {
@@ -137,6 +138,17 @@ func (c *Client) GetListOfCiIdsOfCiTypeName(ciTypeName string) (ciIds CiIds, err
 	}
 
 	ciIds, err = c.GetListOfCiIdsOfCiType(ciTypeId)
+	return
+}
+
+func (c *Client) GetAndBindListOfCiAttributesOfCiTypeName(ciTypeName string, out interface{}) (err error) {
+	ciIds, err := c.GetListOfCiIdsOfCiTypeName(ciTypeName)
+	if err != nil {
+		err = errors.New("failed to get \"" + ciTypeName + "\" ci ids: " + err.Error())
+		return
+	}
+
+	err = c.GetAndBindListOfCiAttributes(ciIds, out)
 	return
 }
 


### PR DESCRIPTION
This provides a ergonomic api to bind cis of a type to a user provided struct slice.

Example:

```golang
type NonStandardDl struct {
	Sam         string   `attr:"non_standard_dl_sam"`
	DisplayName string   `attr:"non_standard_dl_display_name"`
	Status      string   `attr:"non_standard_dl_status"`
	IncludeCe   string   `attr:"non_standard_dl_include_ce"`
	Conditions  []string `attr:"non_standard_dl_condition"`
	Description string   `attr:"non_standard_dl_description"`
}

nonStandardDls := []NonStandardDl{}
err := cmdb.GetAndBindListOfCiAttributesOfCiTypeName("non_standard_dl", &nonStandardDls)
// use nonStandardDls...
```