### PR TITLE
Unify v1 and v2 client creation

### DIFF
--- a/infocmdb/attribute_test.go
+++ b/infocmdb/attribute_test.go
@@ -44,9 +44,7 @@ func TestInfoCMDB_GetAttrDefaultOptionIdByAttrId(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}
@@ -131,9 +129,7 @@ func TestInfoCMDB_UpdateCiAttribute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}

--- a/infocmdb/ci_test.go
+++ b/infocmdb/ci_test.go
@@ -69,9 +69,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}
@@ -148,9 +146,7 @@ func TestInfoCMDB_GetListOfCiIdsOfCiTypeV2(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}
@@ -213,9 +209,7 @@ func TestInfoCMDB_CreateCi(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}

--- a/infocmdb/infocmdb.go
+++ b/infocmdb/infocmdb.go
@@ -35,19 +35,23 @@ type Client struct {
 }
 
 // NewClient returns a new cmdb client
-func NewClient() *Client {
-	return new(Client)
+func NewClient() (c *Client) {
+	c = &Client{
+		v1: v1.New(),
+		v2: v2.New(),
+	}
+	return
 }
 
 // LoadConfig from file in yaml format
-func (c *Client) LoadConfig(f string) (err error) {
-	c.v1, err = v1.New(f)
+func (c *Client) LoadConfig(path string) (err error) {
+	err = c.v1.LoadConfigFile(path)
 	if err != nil {
 		return
 	}
 
-	c.v2 = v2.New()
-	if err = c.v2.LoadConfigFile(f); err != nil {
+	err = c.v2.LoadConfigFile(path)
+	if err != nil {
 		return
 	}
 

--- a/infocmdb/project_test.go
+++ b/infocmdb/project_test.go
@@ -44,9 +44,7 @@ func TestInfoCMDB_AddCiProjectMapping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}

--- a/infocmdb/query_test.go
+++ b/infocmdb/query_test.go
@@ -42,9 +42,7 @@ func TestInfoCMDB_QueryWebservice(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := v2.New()
-			if err := cmdbV2.LoadConfig(tt.fields.v2Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.v2Config)
 			cmdb := &Client{
 				v2: cmdbV2,
 			}

--- a/infocmdb/v1/infocmdb/cmdb.go
+++ b/infocmdb/v1/infocmdb/cmdb.go
@@ -50,22 +50,25 @@ const (
 	ATTRIBUTE_VALUE_TYPE_CI                         = "value_ci"
 )
 
-func (i *Cmdb) LoadConfigFile(path string) (err error) {
-	err = config.LoadYamlConfig(path, &i.Config)
+// New returns a new Cmdb Client to access the V1 Api
+func New() (i *Cmdb) {
+	return &Cmdb{
+		Cache: cache.New(5*time.Minute, 10*time.Minute),
+	}
+}
+
+func (i *Cmdb) LoadConfig(config Config) {
+	i.Config = config
 	return
 }
 
-func New(config string) (i *Cmdb, err error) {
-	i = new(Cmdb)
-	err = i.LoadConfigFile(config)
+func (i *Cmdb) LoadConfigFile(path string) (err error) {
+	err = config.LoadYamlConfig(path, &i.Config)
 	if err != nil {
-		log.Error(err)
-		return nil, err
+		return err
 	}
 
-	i.Cache = cache.New(5*time.Minute, 10*time.Minute)
-
-	return i, nil
+	return
 }
 
 func (i *Cmdb) Login() error {

--- a/infocmdb/v2/infocmdb/ci_test.go
+++ b/infocmdb/v2/infocmdb/ci_test.go
@@ -159,9 +159,7 @@ func TestInfoCMDB_CiListByCiTypeID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdb := New()
 			ut.SetValidConfig(&cmdb.Config)
-			if err := cmdb.LoadConfig(cmdb.Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdb.LoadConfig(cmdb.Config)
 
 			if err := cmdb.Login(); err != nil {
 				t.Fatalf("Login failed: %v\n", err)

--- a/infocmdb/v2/infocmdb/cmdb.go
+++ b/infocmdb/v2/infocmdb/cmdb.go
@@ -69,7 +69,7 @@ const (
 	UPDATE_MODE_SET               = "set"
 )
 
-func (cmdb *Cmdb) LoadConfig(config Config) (err error) {
+func (cmdb *Cmdb) LoadConfig(config Config) {
 	cmdb.Config = config
 	cmdb.Client = client.New(config.Url)
 	return

--- a/infocmdb/v2/infocmdb/login_test.go
+++ b/infocmdb/v2/infocmdb/login_test.go
@@ -57,9 +57,7 @@ func TestInfoCMDB_LoginWithUserPass(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := New()
-			if err := cmdbV2.LoadConfig(tt.fields.Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.Config)
 
 			if err := cmdbV2.Login(); (err != nil) != tt.wantErr {
 				t.Errorf("Cmdb.LoginWithUserPass() error = %v, wantErr %v", err, tt.wantErr)

--- a/infocmdb/v2/infocmdb/query_test.go
+++ b/infocmdb/v2/infocmdb/query_test.go
@@ -38,9 +38,7 @@ func TestInfoCMDB_Query(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdbV2 := New()
-			if err := cmdbV2.LoadConfig(tt.fields.Config); err != nil {
-				t.Fatalf("LoadConfig failed: %v\n", err)
-			}
+			cmdbV2.LoadConfig(tt.fields.Config)
 
 			if err := cmdbV2.Query(tt.args.query, tt.args.out, tt.args.params); (err != nil) != tt.wantErr {
 				t.Errorf("Cmdb.Query() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
I initially changed this to be able to create a test client without the need to read a config file from disk.
I did scrape that idea, but I do think that this client creation unification still makes sense.

To sum it up:
  * Both (V1 and V2) have a `New()` function to create a client with default config.
  * Both have a `LoadConfig(config Config)` function to initialize a config directly from a `Config` struct.
  * Both have a `LoadConfigFile(path string)` function to initialize a config from a yaml file.

This technically is a breaking change, but no code should initialize the v1 and v2 clients directly.
Our workflows are completely unaffected by this.