### PR TITLE
More bindings, consistent binding function names, internal code restructuring

### DIFF
--- a/infocmdb/attribute.go
+++ b/infocmdb/attribute.go
@@ -1,8 +1,6 @@
 package infocmdb
 
 import (
-	"errors"
-	"reflect"
 	"strconv"
 
 	utilCache "github.com/patrickmn/go-cache"
@@ -75,48 +73,6 @@ func (c *Client) GetMapOfCiAttributes(ciIds []int) (ciIdToAttributesMap map[int]
 		ciIdToAttributesMap[ciAttribute.CiID] = ciAttributes
 	}
 
-	return
-}
-
-func (c *Client) GetAndBindCiAttributes(ciId int, out interface{}) (err error) {
-	attributes, err := c.GetCiAttributes(ciId)
-	if err != nil {
-		return
-	}
-
-	return bindCiAttributes(attributes, out)
-}
-
-func (c *Client) GetAndBindListOfCiAttributes(ciIds []int, out interface{}) (err error) {
-	ciIdToAttributesMap, err := c.GetMapOfCiAttributes(ciIds)
-	if err != nil {
-		return
-	}
-
-	outSlicePtr := reflect.ValueOf(out)
-	if outSlicePtr.Kind() != reflect.Ptr {
-		return errors.New("out parameter is not a slice pointer")
-	}
-	outSlice := outSlicePtr.Elem()
-	if outSlice.Kind() != reflect.Slice {
-		return errors.New("out parameter is not a slice pointer")
-	}
-	outSliceElem := reflect.TypeOf(outSlice.Interface()).Elem()
-	outSliceValue := reflect.MakeSlice(outSlice.Type(), 0, 0)
-
-	for _, ciId := range ciIds {
-		ciAttributes := ciIdToAttributesMap[ciId]
-
-		elem := reflect.New(outSliceElem)
-		err = bindCiAttributes(ciAttributes, elem.Interface())
-		if err != nil {
-			return
-		}
-
-		outSliceValue = reflect.Append(outSliceValue, elem.Elem())
-	}
-
-	outSlice.Set(outSliceValue)
 	return
 }
 

--- a/infocmdb/attribute_binding.go
+++ b/infocmdb/attribute_binding.go
@@ -49,6 +49,11 @@ func bindCiAttributes(attributes []CiAttribute, out interface{}) (err error) {
 			if err != nil {
 				return
 			}
+		case "int":
+			err = bindAttrToIntField(attrs, valueField)
+			if err != nil {
+				return
+			}
 		case "[]string":
 			err = bindAttrToStringSliceField(attrs, valueField)
 			if err != nil {
@@ -86,6 +91,35 @@ func bindAttrToStringField(attrs []CiAttribute, field reflect.Value) (err error)
 		attr := attrs[0]
 		return &BindError{
 			Msg:       fmt.Sprintf("failed to map multiple attributes with name \"%v\" to string", attr.AttributeName),
+			FieldName: field.Type().Name(),
+			SrcName:   attr.AttributeName,
+			SrcType:   attr.AttributeType,
+		}
+	}
+
+	return
+}
+
+func bindAttrToIntField(attrs []CiAttribute, field reflect.Value) (err error) {
+	if len(attrs) == 0 {
+		return
+	} else if len(attrs) == 1 {
+		attr := attrs[0]
+		intValue, err := strconv.Atoi(attr.Value)
+		if err != nil {
+			return &BindError{
+				Msg:       fmt.Sprintf("failed to map attribute with name \"%v\" and value \"%v\" to int",
+					attr.AttributeName, attr.Value),
+				FieldName: field.Type().Name(),
+				SrcName:   attr.AttributeName,
+				SrcType:   attr.AttributeType,
+			}
+		}
+		field.SetInt(int64(intValue))
+	} else {
+		attr := attrs[0]
+		return &BindError{
+			Msg:       fmt.Sprintf("failed to map multiple attributes with name \"%v\" to int", attr.AttributeName),
 			FieldName: field.Type().Name(),
 			SrcName:   attr.AttributeName,
 			SrcType:   attr.AttributeType,

--- a/infocmdb/ci.go
+++ b/infocmdb/ci.go
@@ -141,17 +141,6 @@ func (c *Client) GetListOfCiIdsOfCiTypeName(ciTypeName string) (ciIds CiIds, err
 	return
 }
 
-func (c *Client) GetAndBindListOfCiAttributesOfCiTypeName(ciTypeName string, out interface{}) (err error) {
-	ciIds, err := c.GetListOfCiIdsOfCiTypeName(ciTypeName)
-	if err != nil {
-		err = errors.New("failed to get \"" + ciTypeName + "\" ci ids: " + err.Error())
-		return
-	}
-
-	err = c.GetAndBindListOfCiAttributes(ciIds, out)
-	return
-}
-
 type getListOfCiIdsByAttributeValue struct {
 	Data []struct {
 		CiID int `json:"ci_id,string"`
@@ -304,26 +293,4 @@ func (c *Client) GetCiIdByAttributeValue(name string, value string, valueType v2
 	}
 
 	return
-}
-
-func (c *Client) GetAndBindCiByAttributeValue(name string, value string, valueType v2.AttributeValueType, out interface{}) (err error) {
-	ciId, err := c.GetCiIdByAttributeValue(name, value, valueType)
-	if err != nil {
-	    return
-	}
-
-	err = c.GetAndBindCiAttributes(ciId, out)
-	if err != nil {
-	    return
-	}
-
-	return
-}
-
-func (c *Client) GetAndBindCiByAttributeValueText(name string, value string, out interface{}) (err error) {
-	return c.GetAndBindCiByAttributeValue(name, value, v2.ATTRIBUTE_VALUE_TYPE_TEXT, out)
-}
-
-func (c *Client) GetAndBindCiByAttributeValueCi(name string, value string, out interface{}) (err error) {
-	return c.GetAndBindCiByAttributeValue(name, value, v2.ATTRIBUTE_VALUE_TYPE_CI, out)
 }

--- a/infocmdb/ci_binding.go
+++ b/infocmdb/ci_binding.go
@@ -1,10 +1,13 @@
 package infocmdb
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
+
+	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 )
 
 type BindError struct {
@@ -19,7 +22,83 @@ func (e *BindError) Error() string {
 	return e.Msg
 }
 
-func bindCiAttributes(attributes []CiAttribute, out interface{}) (err error) {
+func (c *Client) GetAndBindCi(ciId int, out interface{}) (err error) {
+	attributes, err := c.GetCiAttributes(ciId)
+	if err != nil {
+		return
+	}
+
+	return bindCi(ciId, attributes, out)
+}
+
+func (c *Client) GetAndBindListOfCis(ciIds []int, out interface{}) (err error) {
+	ciIdToAttributesMap, err := c.GetMapOfCiAttributes(ciIds)
+	if err != nil {
+		return
+	}
+
+	outSlicePtr := reflect.ValueOf(out)
+	if outSlicePtr.Kind() != reflect.Ptr {
+		return errors.New("out parameter is not a slice pointer")
+	}
+	outSlice := outSlicePtr.Elem()
+	if outSlice.Kind() != reflect.Slice {
+		return errors.New("out parameter is not a slice pointer")
+	}
+	outSliceElem := reflect.TypeOf(outSlice.Interface()).Elem()
+	outSliceValue := reflect.MakeSlice(outSlice.Type(), 0, 0)
+
+	for _, ciId := range ciIds {
+		ciAttributes := ciIdToAttributesMap[ciId]
+
+		elem := reflect.New(outSliceElem)
+		err = bindCi(ciId, ciAttributes, elem.Interface())
+		if err != nil {
+			return
+		}
+
+		outSliceValue = reflect.Append(outSliceValue, elem.Elem())
+	}
+
+	outSlice.Set(outSliceValue)
+	return
+}
+
+func (c *Client) GetAndBindListOfCisOfCiTypeName(ciTypeName string, out interface{}) (err error) {
+	ciIds, err := c.GetListOfCiIdsOfCiTypeName(ciTypeName)
+	if err != nil {
+		err = errors.New("failed to get \"" + ciTypeName + "\" ci ids: " + err.Error())
+		return
+	}
+
+	err = c.GetAndBindListOfCis(ciIds, out)
+	return
+}
+
+func (c *Client) GetAndBindCiByAttributeValue(name string, value string, valueType v2.AttributeValueType, out interface{}) (err error) {
+	ciId, err := c.GetCiIdByAttributeValue(name, value, valueType)
+	if err != nil {
+		return
+	}
+
+	err = c.GetAndBindCi(ciId, out)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (c *Client) GetAndBindCiByAttributeValueText(name string, value string, out interface{}) (err error) {
+	return c.GetAndBindCiByAttributeValue(name, value, v2.ATTRIBUTE_VALUE_TYPE_TEXT, out)
+}
+
+func (c *Client) GetAndBindCiByAttributeValueCi(name string, value string, out interface{}) (err error) {
+	return c.GetAndBindCiByAttributeValue(name, value, v2.ATTRIBUTE_VALUE_TYPE_CI, out)
+}
+
+
+func bindCi(ciId int, attributes []CiAttribute, out interface{}) (err error) {
 	attrNameToAttrMap := map[string][]CiAttribute{}
 	for _, attr := range attributes {
 		ciAttributes := attrNameToAttrMap[attr.AttributeName]
@@ -90,7 +169,8 @@ func bindAttrToStringField(attrs []CiAttribute, field reflect.Value) (err error)
 	} else {
 		attr := attrs[0]
 		return &BindError{
-			Msg:       fmt.Sprintf("failed to map multiple attributes with name \"%v\" to string", attr.AttributeName),
+			Msg: fmt.Sprintf("failed to map multiple attributes with name \"%v\" to string",
+				attr.AttributeName),
 			FieldName: field.Type().Name(),
 			SrcName:   attr.AttributeName,
 			SrcType:   attr.AttributeType,
@@ -108,7 +188,7 @@ func bindAttrToIntField(attrs []CiAttribute, field reflect.Value) (err error) {
 		intValue, err := strconv.Atoi(attr.Value)
 		if err != nil {
 			return &BindError{
-				Msg:       fmt.Sprintf("failed to map attribute with name \"%v\" and value \"%v\" to int",
+				Msg: fmt.Sprintf("failed to map attribute with name \"%v\" and value \"%v\" to int",
 					attr.AttributeName, attr.Value),
 				FieldName: field.Type().Name(),
 				SrcName:   attr.AttributeName,
@@ -119,7 +199,8 @@ func bindAttrToIntField(attrs []CiAttribute, field reflect.Value) (err error) {
 	} else {
 		attr := attrs[0]
 		return &BindError{
-			Msg:       fmt.Sprintf("failed to map multiple attributes with name \"%v\" to int", attr.AttributeName),
+			Msg: fmt.Sprintf("failed to map multiple attributes with name \"%v\" to int",
+				attr.AttributeName),
 			FieldName: field.Type().Name(),
 			SrcName:   attr.AttributeName,
 			SrcType:   attr.AttributeType,
@@ -147,7 +228,8 @@ func bindAttrToStringSliceField(attrs []CiAttribute, field reflect.Value) (err e
 			}
 		default:
 			return &BindError{
-				Msg:       fmt.Sprintf("failed to map attribute type %v to []string", attr.AttributeType),
+				Msg: fmt.Sprintf("failed to map attribute type %v to []string",
+					attr.AttributeType),
 				FieldName: field.Type().Name(),
 				SrcName:   attr.AttributeName,
 				SrcType:   attr.AttributeType,
@@ -180,7 +262,8 @@ func bindAttrToIntSliceField(attrs []CiAttribute, field reflect.Value) (err erro
 		number, err := strconv.Atoi(trimmedValue)
 		if err != nil {
 			return &BindError{
-				Msg:       fmt.Sprintf("failed convert attribute value \"%v\" to []int: %v", trimmedValue, err.Error()),
+				Msg: fmt.Sprintf("failed convert attribute value \"%v\" to []int: %v",
+					trimmedValue, err.Error()),
 				FieldName: field.Type().Name(),
 				SrcName:   attr.AttributeName,
 				SrcType:   attr.AttributeType,


### PR DESCRIPTION
New features:
* Allow binding of attribute values to type `int`
* Bind ci id to fields with tag `ci:"id"`

Breaking changes:
* Change binding function names from `*BindCiAttributes*` to `*BindCi*`
This shortens the function names without losing any clarity and also allows the binding of the ci id to the output struct.

Internal:
* Move all binding functions to `ci_binding.go`

Example:

```golang
type Example struct {
	CiId        int    `ci:"id"`
	DisplayName string `attr:"example_display_name"`
	RefNumber   int    `attr:"example_ref_number"`
}

func workflow(params infocmdb.WorkflowParams, cmdb *infocmdb.Client) (err error) {
	example = &Example{}
	err = c2a.Cmdb.GetAndBindCi(params.CiId, example)
	if err != nil {
		return
	}
	
	fmt.Printf("Example: %+v\n", example)
	return
}
```