### PR TITLE
Allow GetMapOfCiAttributes to be called without ci ids

### DIFF
--- a/infocmdb/attribute.go
+++ b/infocmdb/attribute.go
@@ -39,6 +39,10 @@ func (c *Client) GetCiAttributes(ciId int) (ciAttributes CiAttributes, err error
 
 func (c *Client) GetMapOfCiAttributes(ciIds []int) (ciIdToAttributesMap map[int]CiAttributes, err error) {
 	ciIdToAttributesMap = map[int]CiAttributes{}
+	
+	if len(ciIds) == 0 {
+		return
+	}
 
 	if err = c.v2.Login(); err != nil {
 		return


### PR DESCRIPTION
This should hopefully be relatively straightforward.
Prevent any call to the InfoCMDB API if the ciIds slice is empty.

This way the workflows can be kept simple as there is no need to do this check in every workflow code 
and the following ranged for loops are simply no-ops.