### PR TITLE
Feature/add create ci type

### DIFF
--- a/infocmdb/ci_type.go
+++ b/infocmdb/ci_type.go
@@ -247,18 +247,18 @@ func (c *Client) TypeIsActive(active bool) func(*ciTypeParams) {
 	}
 }
 
-func (c *Client) TypeIsAttributeAttach(attach bool) func(*ciTypeParams) {
+func (c *Client) TypeIsAttributeAttach(attachAtt bool) func(*ciTypeParams) {
 	return func(obj *ciTypeParams) {
-		if attach == true {
-			obj.IsActive = 1
+		if attachAtt == true {
+			obj.IsAttributeAttach = 1
 		}
 	}
 }
 
-func (c *Client) TypeIsCiAttach(attach bool) func(*ciTypeParams) {
+func (c *Client) TypeIsCiAttach(attachCi bool) func(*ciTypeParams) {
 	return func(obj *ciTypeParams) {
-		if attach == true {
-			obj.IsActive = 1
+		if attachCi == true {
+			obj.IsCiAttach = 1
 		}
 	}
 }

--- a/infocmdb/ci_type.go
+++ b/infocmdb/ci_type.go
@@ -204,9 +204,12 @@ func (c *Client) CreateCiType(typeParams *CiTypeParams) (typeId int, err error) 
 		return
 	}
 
-	typeIdExists, _ := c.GetCiTypeIdByCiTypeName(typeParams.Name)
+	existingTypeId, err := c.GetCiTypeIdByCiTypeName(typeParams.Name)
+	if err != nil && strings.Contains(err.Error(), "query returned no result") == false {
+		return 0, err
+	}
 
-	if typeIdExists == 0 {
+	if existingTypeId == 0 {
 
 		columns := []string{
 			"name",
@@ -275,7 +278,7 @@ func (c *Client) CreateCiType(typeParams *CiTypeParams) (typeId int, err error) 
 		}
 
 	} else {
-		return typeIdExists, nil
+		return existingTypeId, nil
 	}
 
 	return

--- a/infocmdb/ci_type.go
+++ b/infocmdb/ci_type.go
@@ -151,119 +151,54 @@ type respCreateCiType struct {
 	Data    []responseId `json:"data"`
 }
 
-type ciTypeParams struct {
+type CiTypeParams struct {
 	Name                    string
 	Description             string
 	Note                    string
 	ParentCiTypeId          int
 	OrderNumber             int
-	CreateButtonDescription string
-	Icon                    string
-	Query                   string
+	createButtonDescription string
+	icon                    string
+	query                   string
 	DefaultProjectId        int
-	DefaultAttributeId      int
-	DefaultSortAttributeId  int
-	IsDefaultSortAsc        int
+	defaultAttributeId      int
+	defaultSortAttributeId  int
+	isDefaultSortAsc        int
 	IsCiAttach              int
 	IsAttributeAttach       int
-	Tag                     string
-	IsTabEnabled            int
-	IsEventEnabled          int
+	tag                     string
+	isTabEnabled            int
+	isEventEnabled          int
 	IsActive                int
-	UserId                  int
+	userId                  int
 }
 
-func (c *Client) NewTypeParams(options ...func(*ciTypeParams)) *ciTypeParams {
-	typeParams := &ciTypeParams{
+func (c *Client) NewCiTypeParams() (params *CiTypeParams) {
+	params = &CiTypeParams{
 		Name:                    "",
 		Description:             "",
 		Note:                    "",
 		ParentCiTypeId:          0,
 		OrderNumber:             0,
-		CreateButtonDescription: "",
-		Icon:                    "",
-		Query:                   "",
+		createButtonDescription: "",
+		icon:                    "",
+		query:                   "",
 		DefaultProjectId:        0,
-		DefaultAttributeId:      0,
-		DefaultSortAttributeId:  0,
-		IsDefaultSortAsc:        0,
+		defaultAttributeId:      0,
+		defaultSortAttributeId:  0,
+		isDefaultSortAsc:        0,
 		IsCiAttach:              0,
 		IsAttributeAttach:       0,
-		Tag:                     "",
-		IsTabEnabled:            0,
-		IsEventEnabled:          0,
+		tag:                     "",
+		isTabEnabled:            0,
+		isEventEnabled:          0,
 		IsActive:                1,
-		UserId:                  0,
+		userId:                  0,
 	}
-
-	for _, option := range options {
-		option(typeParams)
-	}
-	return typeParams
-
+	return
 }
 
-func (c *Client) TypeWithName(name string) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.Name = name
-	}
-}
-
-func (c *Client) TypeWithDesc(desc string) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.Description = desc
-	}
-}
-
-func (c *Client) TypeWithNote(note string) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.Note = note
-	}
-}
-
-func (c *Client) TypeWithParentCiTypeId(parentId int) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.ParentCiTypeId = parentId
-	}
-}
-
-func (c *Client) TypeWithOrderNumber(orderNum int) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.OrderNumber = orderNum
-	}
-}
-
-func (c *Client) TypeWithDefProjectId(projId int) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		obj.DefaultProjectId = projId
-	}
-}
-
-func (c *Client) TypeIsActive(active bool) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		if active != true {
-			obj.IsActive = 0
-		}
-	}
-}
-
-func (c *Client) TypeIsAttributeAttach(attachAtt bool) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		if attachAtt == true {
-			obj.IsAttributeAttach = 1
-		}
-	}
-}
-
-func (c *Client) TypeIsCiAttach(attachCi bool) func(*ciTypeParams) {
-	return func(obj *ciTypeParams) {
-		if attachCi == true {
-			obj.IsCiAttach = 1
-		}
-	}
-}
-
-func (c *Client) CreateCiType(typeParams *ciTypeParams) (typeId int, err error) {
+func (c *Client) CreateCiType(typeParams *CiTypeParams) (typeId int, err error) {
 
 	if err = c.v2.Login(); err != nil {
 		return
@@ -301,20 +236,20 @@ func (c *Client) CreateCiType(typeParams *ciTypeParams) (typeId int, err error) 
 			typeParams.Note,
 			strconv.Itoa(typeParams.ParentCiTypeId),
 			strconv.Itoa(typeParams.OrderNumber),
-			typeParams.CreateButtonDescription,
-			typeParams.Icon,
-			typeParams.Query,
+			typeParams.createButtonDescription,
+			typeParams.icon,
+			typeParams.query,
 			strconv.Itoa(typeParams.DefaultProjectId),
-			strconv.Itoa(typeParams.DefaultAttributeId),
-			strconv.Itoa(typeParams.DefaultSortAttributeId),
-			strconv.Itoa(typeParams.IsDefaultSortAsc),
+			strconv.Itoa(typeParams.defaultAttributeId),
+			strconv.Itoa(typeParams.defaultSortAttributeId),
+			strconv.Itoa(typeParams.isDefaultSortAsc),
 			strconv.Itoa(typeParams.IsCiAttach),
 			strconv.Itoa(typeParams.IsAttributeAttach),
-			typeParams.Tag,
-			strconv.Itoa(typeParams.IsTabEnabled),
-			strconv.Itoa(typeParams.IsEventEnabled),
+			typeParams.tag,
+			strconv.Itoa(typeParams.isTabEnabled),
+			strconv.Itoa(typeParams.isEventEnabled),
 			strconv.Itoa(typeParams.IsActive),
-			strconv.Itoa(typeParams.UserId),
+			strconv.Itoa(typeParams.userId),
 		}
 
 		params := map[string]string{
@@ -328,10 +263,6 @@ func (c *Client) CreateCiType(typeParams *ciTypeParams) (typeId int, err error) 
 			err = utilError.FunctionError(err.Error())
 			log.Error("Error: ", err)
 			return
-		}
-
-		if response.Success != true {
-			return 0, errors.New("error: " + response.Message)
 		}
 
 		switch len(response.Data) {

--- a/infocmdb/ci_type.go
+++ b/infocmdb/ci_type.go
@@ -247,6 +247,22 @@ func (c *Client) TypeIsActive(active bool) func(*ciTypeParams) {
 	}
 }
 
+func (c *Client) TypeIsAttributeAttach(attach bool) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		if attach == true {
+			obj.IsActive = 1
+		}
+	}
+}
+
+func (c *Client) TypeIsCiAttach(attach bool) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		if attach == true {
+			obj.IsActive = 1
+		}
+	}
+}
+
 func (c *Client) CreateCiType(typeParams *ciTypeParams) (typeId int, err error) {
 
 	if err = c.v2.Login(); err != nil {

--- a/infocmdb/ci_type.go
+++ b/infocmdb/ci_type.go
@@ -3,6 +3,7 @@ package infocmdb
 import (
 	"errors"
 	"strconv"
+	"strings"
 
 	v2 "github.com/infonova/infocmdb-sdk-go/infocmdb/v2/infocmdb"
 	utilError "github.com/infonova/infocmdb-sdk-go/util/error"
@@ -139,6 +140,195 @@ func (c *Client) SetTypeOfCi(ciId int, ciType string) (err error) {
 
 	if response.Success != true {
 		return errors.New("couldn't change ci type to: " + ciType + " for ciid: " + ciIdString + " ,error: " + response.Message)
+	}
+
+	return
+}
+
+type respCreateCiType struct {
+	Success bool         `json:"success"`
+	Message string       `json:"message"`
+	Data    []responseId `json:"data"`
+}
+
+type ciTypeParams struct {
+	Name                    string
+	Description             string
+	Note                    string
+	ParentCiTypeId          int
+	OrderNumber             int
+	CreateButtonDescription string
+	Icon                    string
+	Query                   string
+	DefaultProjectId        int
+	DefaultAttributeId      int
+	DefaultSortAttributeId  int
+	IsDefaultSortAsc        int
+	IsCiAttach              int
+	IsAttributeAttach       int
+	Tag                     string
+	IsTabEnabled            int
+	IsEventEnabled          int
+	IsActive                int
+	UserId                  int
+}
+
+func (c *Client) NewTypeParams(options ...func(*ciTypeParams)) *ciTypeParams {
+	typeParams := &ciTypeParams{
+		Name:                    "",
+		Description:             "",
+		Note:                    "",
+		ParentCiTypeId:          0,
+		OrderNumber:             0,
+		CreateButtonDescription: "",
+		Icon:                    "",
+		Query:                   "",
+		DefaultProjectId:        0,
+		DefaultAttributeId:      0,
+		DefaultSortAttributeId:  0,
+		IsDefaultSortAsc:        0,
+		IsCiAttach:              0,
+		IsAttributeAttach:       0,
+		Tag:                     "",
+		IsTabEnabled:            0,
+		IsEventEnabled:          0,
+		IsActive:                1,
+		UserId:                  0,
+	}
+
+	for _, option := range options {
+		option(typeParams)
+	}
+	return typeParams
+
+}
+
+func (c *Client) TypeWithName(name string) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.Name = name
+	}
+}
+
+func (c *Client) TypeWithDesc(desc string) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.Description = desc
+	}
+}
+
+func (c *Client) TypeWithNote(note string) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.Note = note
+	}
+}
+
+func (c *Client) TypeWithParentCiTypeId(parentId int) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.ParentCiTypeId = parentId
+	}
+}
+
+func (c *Client) TypeWithOrderNumber(orderNum int) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.OrderNumber = orderNum
+	}
+}
+
+func (c *Client) TypeWithDefProjectId(projId int) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		obj.DefaultProjectId = projId
+	}
+}
+
+func (c *Client) TypeIsActive(active bool) func(*ciTypeParams) {
+	return func(obj *ciTypeParams) {
+		if active != true {
+			obj.IsActive = 0
+		}
+	}
+}
+
+func (c *Client) CreateCiType(typeParams *ciTypeParams) (typeId int, err error) {
+
+	if err = c.v2.Login(); err != nil {
+		return
+	}
+
+	typeIdExists, _ := c.GetCiTypeIdByCiTypeName(typeParams.Name)
+
+	if typeIdExists == 0 {
+
+		columns := []string{
+			"name",
+			"description",
+			"note",
+			"parent_ci_type_id",
+			"order_number",
+			"create_button_description",
+			"icon",
+			"query",
+			"default_project_id",
+			"default_attribute_id",
+			"default_sort_attribute_id",
+			"is_default_sort_asc",
+			"is_ci_attach",
+			"is_attribute_attach",
+			"tag",
+			"is_tab_enabled",
+			"is_event_enabled",
+			"is_active",
+			"user_id",
+		}
+
+		values := []string{
+			typeParams.Name,
+			typeParams.Description,
+			typeParams.Note,
+			strconv.Itoa(typeParams.ParentCiTypeId),
+			strconv.Itoa(typeParams.OrderNumber),
+			typeParams.CreateButtonDescription,
+			typeParams.Icon,
+			typeParams.Query,
+			strconv.Itoa(typeParams.DefaultProjectId),
+			strconv.Itoa(typeParams.DefaultAttributeId),
+			strconv.Itoa(typeParams.DefaultSortAttributeId),
+			strconv.Itoa(typeParams.IsDefaultSortAsc),
+			strconv.Itoa(typeParams.IsCiAttach),
+			strconv.Itoa(typeParams.IsAttributeAttach),
+			typeParams.Tag,
+			strconv.Itoa(typeParams.IsTabEnabled),
+			strconv.Itoa(typeParams.IsEventEnabled),
+			strconv.Itoa(typeParams.IsActive),
+			strconv.Itoa(typeParams.UserId),
+		}
+
+		params := map[string]string{
+			"argv1": "`" + strings.Join(columns, "`, `") + "`",
+			"argv2": "'" + strings.Join(values, "', '") + "'",
+		}
+
+		response := respCreateCiType{}
+		err = c.v2.Query("int_createCIType", &response, params)
+		if err != nil {
+			err = utilError.FunctionError(err.Error())
+			log.Error("Error: ", err)
+			return
+		}
+
+		if response.Success != true {
+			return 0, errors.New("error: " + response.Message)
+		}
+
+		switch len(response.Data) {
+		case 0:
+			err = utilError.FunctionError(typeParams.Name + " - " + v2.ErrNoResult.Error())
+		case 1:
+			typeId = response.Data[0].Id
+		default:
+			err = utilError.FunctionError(typeParams.Name + " - " + v2.ErrTooManyResults.Error())
+		}
+
+	} else {
+		return typeIdExists, nil
 	}
 
 	return


### PR DESCRIPTION
Usage:

```
typeParams := cmdb.NewTypeParams(cmdb.TypeWithName("little_test_testis"),cmdb.TypeWithDesc("opis tipa"),cmdb.TypeWithNote("to be or not to be"), cmdb.TypeWithDefProjectId(1), cmdb.TypeWithOrderNumber(11),cmdb.TypeWithParentCiTypeId(1))

ciType, err := cmdb.CreateCiType(typeParams)
```

I created the NewTypeParams function because i wanted the variables in the struct to have defult values and only some of them can be changed over functions TypeWithName, TypeWithDesc, TypeWithNote, TypeWithDefProjectId,TypeWithOrderNumber, TypeWithParentCiTypeId, TypeIsActive.... You can change all or only some.
You dont have to create a whole new struct with all values when you are creating a new Ci type. Did I overdo it? 