### PR TITLE
Fix formatting of notification params

### DIFF
--- a/infocmdb/v1/infocmdb/notification.go
+++ b/infocmdb/v1/infocmdb/notification.go
@@ -59,20 +59,20 @@ func (i *Cmdb) SendNotification(notifyName string, params NotifyParams) (resp No
 		return resp, errors.New("failed to create a new request. Error: " + err.Error())
 	}
 
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header["Content-Type"] = []string{"application/x-www-form-urlencoded"}
 
 	if params.From != "" {
-		req.Header.Add("From", params.From)
+		req.Header["From"] = []string{params.From}
 	}
 
 	if params.FromName != "" {
-		req.Header.Add("FromName", params.FromName)
+		req.Header["FromName"] = []string{params.FromName}
 	}
 
 	allRecipients := strings.Join(params.Recipients, ";")
 
 	if allRecipients != "" {
-		req.Header.Add("Recipients", allRecipients)
+		req.Header["Recipients"] = []string{allRecipients}
 	}
 
 	recipientsCC := strings.Join(params.RecipientsCC, ";")
@@ -84,17 +84,17 @@ func (i *Cmdb) SendNotification(notifyName string, params NotifyParams) (resp No
 	recipientsBCC := strings.Join(params.RecipientsBCC, ";")
 
 	if recipientsBCC != "" {
-		req.Header.Add("RecipientsBCC", recipientsBCC)
+		req.Header["RecipientsBCC"] = []string{recipientsBCC}
 	}
 
 	allAttachments := strings.Join(params.AttachmentsPaths, ";")
 
 	if allAttachments != "" {
-		req.Header.Add("Attachments", allAttachments)
+		req.Header["Attachments"] = []string{allAttachments}
 	}
 
 	if params.Subject != "" {
-		req.Header.Add("Subject", params.Subject)
+		req.Header["Subject"] = []string{params.Subject}
 	}
 
 	response, err := httpClient.Do(req)


### PR DESCRIPTION
The golang request header `Add` method fucks up the header names,
so it needs to be avoided like a plague.

The official workaround seems to be accessing the map directly.